### PR TITLE
Latest ipywidgets

### DIFF
--- a/psctb/modeltools/_paths.py
+++ b/psctb/modeltools/_paths.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from os import path, mkdir, listdir
+import re
 
 from pysces import output_dir
 
@@ -59,8 +60,8 @@ def next_suffix(directory, base_name, ext=None):
     for each in files:
         if each.startswith(base_name) and each.endswith(ext):
             start = len(base_name + '_')
-            end = start + 1
-            num = int(each[start:end])
+            m = re.search('\d+', each[start:])
+            num = int(m.group())
             if num >= next_num:
                 next_num = num + 1
     return next_num

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pysces
 matplotlib
 numpydoc
 networkx==1.11
-ipywidgets==6.0.0
-widgetsnbextension==2.0.0
+ipywidgets
+widgetsnbextension
 jupyter-pip
 pandas


### PR DESCRIPTION
I have fixed the display of the figures using the latest version of `ipywidgets` and `widgetsnbextension`. The main change has been the explicit definitions of separate `Output`s (instances of `ipywidgets.Output()`) for the figure and for the widgets (either the toggle button widgets or the figure adjust widgets. This allows one to selectively clear the figure output while keeping the widgets in place.

This works for both the `notebook` and `inline` matplotlib backends. The only caveat is that for the `notebook` (nbAgg) backend, the figure itself is also a live object, so with repeated calls to `.interact()`, it jumps back to the figure that was created first even if the `.interact()` call is in a subsequent cell (e.g. `basic_usage.ipynb`). This has however been the case since the beginning. The inline backend now works again as expected, and for the users preferring the notebook backend, this should also be possible since I assume in the normal workflow `.interact()` would only be called once for a particular model and analysis. I would however agree that the inline backend is still the preferred backend for this package.

Other changes:
- tweaking of figsize so that the figures are displayed at a reasonable size for both the inline and notebook backends
- changing of the figure legend layout to 5 columns (verified that it fits in)
- change layout of `Save` button and remove empty header line to save on precious screen real estate
- replace `w.on_trait_change` (deprecated) with `w.observe`
- fix autogeneration of filename suffixes with >10 files
- minor typo and bugfixes

Carl, I would appreciate it if you could briefly review the code and then merge.